### PR TITLE
Updated audit message for user name changes

### DIFF
--- a/WhiffBot/Audit.cs
+++ b/WhiffBot/Audit.cs
@@ -172,7 +172,7 @@ namespace WhiffBot
             if (channel == null)
                 return;
 
-            var discriminator = oldUser.DiscriminatorValue.toString()
+            var discriminator = oldUser.DiscriminatorValue.toString();
             var fullUsername = $"{oldUser.Username}#{discriminator}"
 
             await channel.SendMessageAsync($"```NAME CHANGE: [{fullUsername}] {oldUser.Nickname ?? oldUser.Username} => {newUser.Nickname ?? newUser.Username}```");

--- a/WhiffBot/Audit.cs
+++ b/WhiffBot/Audit.cs
@@ -173,7 +173,7 @@ namespace WhiffBot
                 return;
 
             var discriminator = oldUser.DiscriminatorValue.toString();
-            var fullUsername = $"{oldUser.Username}#{discriminator}"
+            var fullUsername = $"{oldUser.Username}#{discriminator}";
 
             await channel.SendMessageAsync($"```NAME CHANGE: [{fullUsername}] {oldUser.Nickname ?? oldUser.Username} => {newUser.Nickname ?? newUser.Username}```");
         }

--- a/WhiffBot/Audit.cs
+++ b/WhiffBot/Audit.cs
@@ -172,10 +172,7 @@ namespace WhiffBot
             if (channel == null)
                 return;
 
-            var discriminator = oldUser.DiscriminatorValue.toString();
-            var fullUsername = $"{oldUser.Username}#{discriminator}";
-
-            await channel.SendMessageAsync($"```NAME CHANGE: [{fullUsername}] {oldUser.Nickname ?? oldUser.Username} => {newUser.Nickname ?? newUser.Username}```");
+            await channel.SendMessageAsync($"```NAME CHANGE [{oldUser}] [{oldUser.Nickname ?? oldUser.Username}] => [{newUser.Nickname ?? newUser.Username}]```");
         }
 
         /// <summary>
@@ -200,7 +197,7 @@ namespace WhiffBot
             if (channel == null)
                 return;
 
-            await channel.SendMessageAsync($"```CHANNEL NAME CHANGE: [{oldGuildChannel.Name}] => [{newGuildChannel.Name}]```");
+            await channel.SendMessageAsync($"```CHANNEL NAME CHANGE [{oldGuildChannel.Name}] => [{newGuildChannel.Name}]```");
         }
 
         /// <summary>
@@ -221,7 +218,7 @@ namespace WhiffBot
             if (channel == null)
                 return;
 
-            await channel.SendMessageAsync($"```ROLE NAME CHANGE: [{oldRole.Name}] => [{newRole.Name}]```");
+            await channel.SendMessageAsync($"```ROLE NAME CHANGE [{oldRole.Name}] => [{newRole.Name}]```");
         }
     }
 }

--- a/WhiffBot/Audit.cs
+++ b/WhiffBot/Audit.cs
@@ -172,7 +172,10 @@ namespace WhiffBot
             if (channel == null)
                 return;
 
-            await channel.SendMessageAsync($"```NAME CHANGE: [{oldUser.Username}] => [{newUser.Nickname ?? newUser.Username}]```");
+            var discriminator = oldUser.DiscriminatorValue.toString()
+            var fullUsername = $"{oldUser.Username}#{discriminator}"
+
+            await channel.SendMessageAsync($"```NAME CHANGE: [{fullUsername}] {oldUser.Nickname ?? oldUser.Username} => {newUser.Nickname ?? newUser.Username}```");
         }
 
         /// <summary>


### PR DESCRIPTION
Updated the message sent to #audit-logs channel when a user changes their name:

- Included `DiscriminatorValue` to (hopefully) capture tag
- Added full discord name to message
- Tried including `oldUser.Nickname` if possible to show the name change